### PR TITLE
return empty array if manifest file was not found

### DIFF
--- a/gogrepo.py
+++ b/gogrepo.py
@@ -204,7 +204,7 @@ def load_manifest(filepath=MANIFEST_FILENAME):
             ad = r.read().replace('{', 'AttrDict(**{').replace('}', '})')
         return eval(ad)
     except IOError:
-        return AttrDict()
+        return []
 
 
 def save_manifest(items):


### PR DESCRIPTION
when I executed script for the first time it printed an error.
I found out that returning an emtpy array when the manifest file was not found keeps the script ongoing.
Everything else worked then for me.

As I am not a python programmer please review if the change is correct :-)
Thanks for the nice script!