### PR TITLE
Added option to exclude patches from download

### DIFF
--- a/gogrepo.py
+++ b/gogrepo.py
@@ -815,7 +815,7 @@ def cmd_download(savedir, skipextras, skipgames, skipids, skippatches, dryrun, i
             old_downloads = item.downloads
             item.downloads = []
             for download in old_downloads:
-                if download['version'] is not None and ('->' in download['version'] or download['name'].startswith('patch')):  # This is a patch
+                if (download['version'] is not None and '->' in download['version']) or download['name'].startswith('patch'):  # This is a patch
                     if not skippatches:
                         item.downloads.append(download)
                 else:  # This is a game file


### PR DESCRIPTION
This adds an option to the download command to skip patch files.

This is useful if you only want to store the latest version of the game files on your disk and therefore have no need for the patch files.