### PR TITLE
Duplicate file name fix

### DIFF
--- a/gogrepo.py
+++ b/gogrepo.py
@@ -29,6 +29,7 @@ import datetime
 import shutil
 import socket
 import xml.etree.ElementTree
+import copy
 
 # python 2 / 3 imports
 try:
@@ -442,6 +443,59 @@ def filter_dlcs(item, dlc_list, lang_list, os_list):
         filter_downloads(item.downloads, dlc_dict['downloads'], lang_list, os_list)
         filter_extras(item.extras, dlc_dict['extras'])
         filter_dlcs(item, dlc_dict['dlcs'], lang_list, os_list)  # recursive
+        
+def deDuplicateList(duplicatedList,existingItems):   
+    deDuplicatedList = []
+    for update_item in duplicatedList:
+        if update_item.name is not None:                
+            dummy_item = copy.copy(update_item)
+            deDuplicatedName = deDuplicateName(dummy_item,existingItems)
+            if deDuplicatedName is not None:
+                if (update_item.name != deDuplicatedName):
+                    info('  -> ' + update_item.name + ' already exists in this game entry with a different size and/or md5, this file renamed to ' + deDuplicatedName)                        
+                    update_item.name = deDuplicatedName
+                deDuplicatedList.append(update_item)
+            else:
+                info('  -> ' + update_item.name + ' already exists in this game entry with same size/md5, skipping adding this file to the manifest') 
+        else: 
+            #Placeholder for an item coming soon, pass through
+            deDuplicatedList.append(update_item)
+    return deDuplicatedList        
+        
+        
+def deDuplicateName(potentialItem,clashDict):
+    try: 
+        #Check if Name Exists
+        existingList = clashDict[potentialItem.name] 
+        try:
+            #Check if this md5 / size pair have already been resolved
+            idx = existingList.index((potentialItem.md5,potentialItem.size))
+            return None
+        except ValueError:
+            root,ext = os.path.splitext(potentialItem.name)
+            if (ext != ".bin"):
+                potentialItem.name = root + "("+str(len(existingList)) + ")" + ext
+            else:
+                #bin file, adjust name to account for gogs weird extension method
+                setDelimiter = root.rfind("-")
+                try:
+                    setPart = int(root[setDelimiter+1:])
+                except ValueError:
+                    #This indicators a false positive. The "-" found was part of the file name not a set delimiter. 
+                    setDelimiter = -1 
+                if (setDelimiter == -1):
+                    #not part of a bin file set , some other binary file , treat it like a non .bin file
+                    potentialItem.name = root + "("+str(len(existingList)) + ")" + ext
+                else:    
+                    potentialItem.name = root[:setDelimiter] + "("+str(len(existingList)) + ")" + root[setDelimiter:] + ext
+            existingList.append((potentialItem.md5,potentialItem.size)) #Mark as resolved 
+            return deDuplicateName(potentialItem,clashDict)        
+    except KeyError:
+        #No Name Clash
+        clashDict[potentialItem.name] = [(potentialItem.md5,potentialItem.size)]
+        return potentialItem.name   
+        
+        
 
 
 def process_argv(argv):
@@ -711,6 +765,10 @@ def cmd_update(os_list, lang_list, skipknown, updateonly, id):
                 filter_extras(item.extras, item_json_data['extras'])
                 filter_dlcs(item, item_json_data['dlcs'], lang_list, os_list)
 
+                existingItems = {}                
+                item.downloads = deDuplicateList(item.downloads,existingItems)  
+                item.extras = deDuplicateList(item.extras,existingItems)
+                
                 # update gamesdb with new item
                 item_idx = item_checkdb(item.id, gamesdb)
                 if item_idx is not None:


### PR DESCRIPTION
This resolves a problem of never being able to be fully up to date / verified when GOG has 2 files with the same file name but different Sizes/MD5s in one game entry.  It does so by inserting a numeric indicator into the file name, such that the set integrity of exe / bin groups is preserved. 

It also recognizes when the same file is listed twice (eg as a base game goodie and again as part of a special edition) and skips adding to the manifest in that case. 