### PR TITLE
Move old versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ update or download command. Run this once first before doing update and download
     -h, --help            show this help message and exit
     -os [OS [OS ...]]     operating system(s) (ex. windows linux mac)
     -lang [LANG [LANG ...]]  game language(s) (ex. en fr de)
+    -moveoutdated         move outdated files to version sub-directories
     -skipknown            only update new games in your library
     -updateonly           only update games with the updated tag in your library
     -id <title>           specify the game to update by 'title' from the manifest
                           <title> can be found in the !info.txt of the game directory
+    savedir               directory with saved downloads
 
 --
 

--- a/gogrepo.py
+++ b/gogrepo.py
@@ -1134,8 +1134,22 @@ def cmd_clean(cleandir, dryrun):
                     expected_filenames.append(game_item.name)
                 for cur_dir_file in os.listdir(cur_fulldir):
                     if os.path.isdir(os.path.join(cleandir, cur_dir, cur_dir_file)):
-                        continue  # leave subdirs alone
-                    if cur_dir_file not in expected_filenames and cur_dir_file not in ORPHAN_FILE_EXCLUDE_LIST:
+                        # orphan old version folders
+                        if cur_dir_file.startswith('!version'):
+                            info('Orphaning old version folder {}'.format(os.path.join(cleandir, cur_dir, cur_dir_file)))
+                            have_cleaned = True
+                            dest_dir = os.path.join(orphan_root_dir, cur_dir)
+                            if not os.path.isdir(dest_dir):
+                                os.makedirs(dest_dir)
+                            dir_to_move = os.path.join(cleandir, cur_dir, cur_dir_file)
+                            total_size += get_total_size(dir_to_move)
+                            if not dryrun:
+                                try:
+                                    shutil.move(dir_to_move, dest_dir)
+                                except Exception as e:
+                                    error(e)
+                        # leave other subdirs alone
+                    elif cur_dir_file not in expected_filenames and cur_dir_file not in ORPHAN_FILE_EXCLUDE_LIST:
                         info("orphaning file '{}'".format(os.path.join(cur_dir, cur_dir_file)))
                         have_cleaned = True
                         dest_dir = os.path.join(orphan_root_dir, cur_dir)


### PR DESCRIPTION
Adds an option (-moveoutdated argument) for the update command to move old version of files to separate sub-directories to keep the main game directory clean and older versions organized. Sub-directories are prefixed with '!version_' and the version stored in the manifest is appended.
The clean command is aware of the '!version_' sub-directories and will orphan then accordingly.
This shouldn't break any existing workflows you might have.