### PR TITLE
Adds various features and new behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ I recommend you use `pip` to install the above python modules.
 TODO
 ----
 * ~~add ability to update and download specific games or new-items only~~
-* add 'clean' command to orphan/remove old or unexpected files to keep your collection clean with only the latest files
+* ~~add 'clean' command to orphan/remove old or unexpected files to keep your collection clean with only the latest files~~
 * support resuming manifest updating
 * ~~add support for incremental manifest updating (ie. only fetch newly added games) rather than fetching entire collection information~~
 * ability to customize/remap default game directory name

--- a/gogrepo.py
+++ b/gogrepo.py
@@ -258,12 +258,14 @@ def load_manifest(filepath=MANIFEST_FILENAME):
       with codecs.open(MANIFEST_FILENAME, 'rU', 'utf-8') as r:
        ad = r.read().replace('{', 'AttrDict(**{').replace('}', '})')
       return eval(ad)
+     except:
+        return []
     if sys.version_info[0] == 3:
      try:
       with codecs.open(MANIFEST_FILENAME, 'r', 'utf-8') as r:
        ad = r.read().replace('{', 'AttrDict(**{').replace('}', '})')
       return eval(ad)
-    except IOError:
+     except IOError:
         return []
 
 


### PR DESCRIPTION
Changes introduced in this rollup include:

* Discriminating on Python major version in load_manifest
  * The "universal newline" flag has been assumed by default in all versions of Python 3, was deprecated in 3.3, and no longer functions in 3.11. This code includes a branch on detected Python major version to perform the correct open() command.

* Adds a -skippatches flag to download and verify commands (Thanks to Xeniac-at)
  * There are a lot of patches available, and people may or may not want to download them all for space concerns. This feature allows the user to skip them. Crucially, the current implementation leaves the patch information in the local manifest, allowing users to download patches on an as-desired basis. This behavior is also added to the verify command, reducing the number of "missing file" entries.

* Updates functionality for the verify command
  * By default, this script counts up the number of items that fail to verify, but don't list them. That isn't as helpful as it could be, so a new behavior additionally collects the directory path of the failed item(s) and lists them at the end of the operation.

* Various grammatical fixes